### PR TITLE
Updated Help text. Including "usage" in the argparse.ArgumentParser()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 #ignore PyCharm files
 .idea/
 ../.idea/
+
+#ignore Python virtual environment used for testing
+test-manifests/virt-env

--- a/hubmap_clt/__main__.py
+++ b/hubmap_clt/__main__.py
@@ -147,7 +147,7 @@ def batch_transfer(endpoint_list, globus_endpoint_uuid, local_id, args):
         if os.path.basename(full_path) == "":
             is_directory = True
         if is_directory is False:
-            line = f'"{full_path}" ~/{args.destination}/{each["hubmap_id"]}-{each["uuid"]}/{os.path.basename(full_path)} \n'
+            line = f'"{full_path}" "~/{args.destination}/{each["hubmap_id"]}-{each["uuid"]}/{os.path.basename(full_path)}" \n'
         else:
             if each["specific_path"] != "/":
                 slash_index = full_path.rstrip('/').rfind("/")
@@ -155,7 +155,7 @@ def batch_transfer(endpoint_list, globus_endpoint_uuid, local_id, args):
                 local_dir.replace("/", os.sep)
             else:
                 local_dir = os.sep
-            line = f'"{full_path}" ~/{args.destination}/{each["hubmap_id"]}-{each["uuid"]}/{local_dir.lstrip(os.sep)} --recursive \n'
+            line = f'"{full_path}" "~/{args.destination}/{each["hubmap_id"]}-{each["uuid"]}/{local_dir.lstrip(os.sep)}" --recursive \n'
         temp.write(line)
     temp.seek(0)
     # if running in a linux/posix environment, default folder will be ~/Downloads.

--- a/hubmap_clt/__main__.py
+++ b/hubmap_clt/__main__.py
@@ -14,15 +14,7 @@ INGEST_DEV_WEBSERVICE_URL = "https://ingest.api.hubmapconsortium.org/"
 
 def main():
     # Configure the top level Parser
-    parser = argparse.ArgumentParser(prog='hubmap-clt', description='Hubmap Command Line Transfer', usage='''
-        $ hubmap-clt command
- 
-        List of commands:
-            transfer    Transfer files and directories to local endpoint from information on a manifest file 
-            login       Login to Globus via the default web browser
-            whoami      Show information about the currently logged in user if logged in
- 
-    ''')
+    parser = argparse.ArgumentParser(prog='hubmap-clt', description='Hubmap Command Line Transfer')
     subparsers = parser.add_subparsers()
 
     # Create Subparsers to give subcommands
@@ -94,9 +86,8 @@ def transfer(args):
     # webservice back to the manifest entry it came from.
     id_list = []
     manifest_dict = {}
-    line_count = 0
     for x in f:
-        if line_count != 0:
+        if x.startswith("dataset_id") is False:
             if x != "":
                 try:
                     line = shlex.split(x)
@@ -111,7 +102,6 @@ def transfer(args):
                 #     sys.exit(1)
                 id_list.append(line[0].strip('"'))
                 manifest_dict[line[0].strip('"')] = line[1].strip('"')
-        line_count = line_count + 1
     if len(id_list) == 0:
         print(f"File {file_name} contained nothing or only blank lines. \n"
               f"Each line on the manifest must be the id for the dataset/upload, followed by its path and \n"

--- a/hubmap_clt/__main__.py
+++ b/hubmap_clt/__main__.py
@@ -144,7 +144,7 @@ def transfer(args):
         print(f"Globus transfer successfully initiated. Files to be downloaded to <Home-Folder>/{destination} where "
               f"Home-Folder is the default download\ndirectory designated by Globus Connect Personal. "
               f"For instructions on how to view the current GCP download directory, visit:\n"
-              f"softwaredocs.hubmapconsortium.org/clt. \n\nDownloading from endpoint(s): ")
+              f"https://software.docs.hubmapconsortium.org/clt. \n\nDownloading from endpoint(s): ")
         for endpoint in at_least_one_success:
             print(f"\t{endpoint}")
         print(f"\nThe status of the transfer(s) may be found at https://app.globus.org/activity. For more information,"

--- a/hubmap_clt/__main__.py
+++ b/hubmap_clt/__main__.py
@@ -141,7 +141,10 @@ def transfer(args):
     if len(at_least_one_success) > 0:
         destination = args.destination.replace("\\", os.sep)
         destination = destination.replace("/", os.sep)
-        print(f"Globus transfer successfully initiated. Files to be downloaded to {destination} from endpoint(s):")
+        print(f"Globus transfer successfully initiated. Files to be downloaded to <Home-Folder>/{destination} where "
+              f"Home-Folder is the default download\ndirectory designated by Globus Connect Personal. "
+              f"For instructions on how to view the current GCP download directory, visit:\n"
+              f"softwaredocs.hubmapconsortium.org/clt. \n\nDownloading from endpoint(s): ")
         for endpoint in at_least_one_success:
             print(f"\t{endpoint}")
         print(f"\nThe status of the transfer(s) may be found at https://app.globus.org/activity. For more information,"

--- a/hubmap_clt/__main__.py
+++ b/hubmap_clt/__main__.py
@@ -151,9 +151,6 @@ def transfer(args):
 # and lines from the incoming manifest file are transformed into how they are needed by globus
 def batch_transfer(endpoint_list, globus_endpoint_uuid, local_id, args):
     temp = tempfile.NamedTemporaryFile(mode='w+t', delete=False)
-    user_root = os.path.expanduser("~")
-    if os.name == 'nt':
-        user_root = user_root[3:]
     for each in endpoint_list:
         is_directory = False
         # We use "/" rather than os.sep because the file system for globus always uses "/"
@@ -164,14 +161,14 @@ def batch_transfer(endpoint_list, globus_endpoint_uuid, local_id, args):
         if os.path.basename(full_path) == "":
             is_directory = True
         if is_directory is False:
-            line = f'"{full_path}" "{user_root}/{args.destination}/{each["hubmap_id"]}-{each["uuid"]}/{os.path.basename(full_path)}" \n'
+            line = f'"{full_path}" "~/{args.destination}/{each["hubmap_id"]}-{each["uuid"]}/{os.path.basename(full_path)}" \n'
         else:
             if each["specific_path"] != "/":
                 slash_index = full_path.rstrip('/').rfind("/")
                 local_dir = full_path[slash_index:].rstrip().rstrip('/')
             else:
                 local_dir = "/"
-            line = f'"{full_path}" "{user_root}/{args.destination}/{each["hubmap_id"]}-{each["uuid"]}/{local_dir.lstrip("/")}" --recursive \n'
+            line = f'"{full_path}" "~/{args.destination}/{each["hubmap_id"]}-{each["uuid"]}/{local_dir.lstrip("/")}" --recursive \n'
         line = line.replace("\\", "/")
         temp.write(line)
     temp.seek(0)

--- a/hubmap_clt/__main__.py
+++ b/hubmap_clt/__main__.py
@@ -80,7 +80,7 @@ def transfer(args):
             if substring == "True":
                 endpoint_connected = True
     if endpoint_connected is False:
-        print(f"The endpoint {local_id} is not active. Please consult the Globus Connect documentation  \n "
+        print(f"The endpoint {local_id} \nis not active. Please consult the Globus Connect documentation  \n"
               f"to start the local endpoint. Once the endpoint is connected, try again")
         sys.exit(1)
 

--- a/hubmap_clt/__main__.py
+++ b/hubmap_clt/__main__.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import re
-import json
 import argparse
 import os.path
 import subprocess
@@ -37,14 +36,14 @@ def main():
     parser_login.set_defaults(func=login)
     parser_whoami.set_defaults(func=whoami)
     parser_logout.set_defaults(func=logout)
-    parser.set_defaults(func=base_case)
 
     # Parse the arguments and call appropriate functions
+    if len(sys.argv) == 1 or '-h' in sys.argv or '--help' in sys.argv:
+        print("usage: ", end="")
+        print(help_text)
+        sys.exit(0)
     args = parser.parse_args()
-    if len(sys.argv) == 1:
-        args.func(args, parser)
-    else:
-        args.func(args)
+    args.func(args)
 
 
 # This is the primary function of the hubmap_clt. Accepts a single mandatory argument which is the path/name of a
@@ -92,7 +91,7 @@ def transfer(args):
     for x in f:
         if x.startswith("dataset_id") is False:
             if x != "" and x != "\n":
-                pattern = '^(\S+)[ \t]+([^\t\n]+)'
+                pattern = '^(\\S+)[ \t]+([^\t\n]+)'
                 matches = re.search(pattern, x)
                 if matches is None:
                     print(f"There was a problem with one of the entries in {file_name}. Please review {file_name} and "
@@ -199,11 +198,6 @@ def logout(args):
     logout_process.wait()
     print("\nYou are now successfully logged out of the HuBMAP Command-Line Transfer.")
     logout_process.communicate()[0].decode('utf-8')
-
-
-def base_case(args, parser):
-    # If no sub-commands are given, the help and usage information will be displayed
-    parser.print_usage()
 
 
 if __name__ == '__main__':

--- a/hubmap_clt/__main__.py
+++ b/hubmap_clt/__main__.py
@@ -147,7 +147,7 @@ def batch_transfer(endpoint_list, globus_endpoint_uuid, local_id, args):
         if os.path.basename(full_path) == "":
             is_directory = True
         if is_directory is False:
-            line = f'"{full_path}" "~/{args.destination}/{each["hubmap_id"]}-{each["uuid"]}/{os.path.basename(full_path)}" \n'
+            line = f'"{full_path}" "{os.path.expanduser("~")}{os.sep}{args.destination}{os.sep}{each["hubmap_id"]}-{each["uuid"]}{os.sep}{os.path.basename(full_path)}" \n'
         else:
             if each["specific_path"] != "/":
                 slash_index = full_path.rstrip('/').rfind("/")
@@ -155,11 +155,9 @@ def batch_transfer(endpoint_list, globus_endpoint_uuid, local_id, args):
                 local_dir.replace("/", os.sep)
             else:
                 local_dir = os.sep
-            line = f'"{full_path}" "~/{args.destination}/{each["hubmap_id"]}-{each["uuid"]}/{local_dir.lstrip(os.sep)}" --recursive \n'
+            line = f'"{full_path}" "{os.path.expanduser("~")}{os.sep}{args.destination}{os.sep}{each["hubmap_id"]}-{each["uuid"]}{os.sep}{local_dir.lstrip(os.sep)}" --recursive \n'
         temp.write(line)
     temp.seek(0)
-    # if running in a linux/posix environment, default folder will be ~/Downloads.
-    # if not, don't specify the target directory. Will need to add implementation for other OS's
     globus_transfer_process = subprocess.Popen(["globus", "transfer", globus_endpoint_uuid, local_id, "--batch",
                                                 temp.name], stdout=subprocess.PIPE)
     globus_transfer = globus_transfer_process.communicate()[0].decode('utf-8')

--- a/hubmap_clt/__main__.py
+++ b/hubmap_clt/__main__.py
@@ -13,6 +13,8 @@ from pathlib import Path
 INGEST_DEV_WEBSERVICE_URL = "https://ingest.api.hubmapconsortium.org/"
 
 
+# This handles the argument parsing for the command line interface. Business logic is relegated to the individual
+# functions corresponding to each subcommand
 def main():
     # Import help text from file
     p = Path(__file__).with_name("clt-help.txt")
@@ -135,6 +137,9 @@ def transfer(args):
         batch_transfer(endpoint_list, each, local_id, args)
 
 
+# Construct the file used for the globus batch tranfer. Each source endpoint id needs a separate globus transfer.
+# This also allows each one to have a unique task id which is relayed back to the user. A temporary file is created
+# and lines from the incoming manifest file are transformed into how they are needed by globus
 def batch_transfer(endpoint_list, globus_endpoint_uuid, local_id, args):
     temp = tempfile.NamedTemporaryFile(mode='w+t')
     for each in endpoint_list:
@@ -168,9 +173,9 @@ def batch_transfer(endpoint_list, globus_endpoint_uuid, local_id, args):
     temp.close()
 
 
+# Makes the command "globus whoami". If the user is logged in, their identity will be printed. If they are not
+# Logged in, they will be prompted to use the command "hubmap-clt login"
 def whoami(args):
-    # Makes the command "globus whoami". If the user is logged in, their identity will be printed. If they are not
-    # Logged in, they will be prompted to use the command "hubmap-clt login"
     whoami_process = subprocess.Popen(["globus", "whoami"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     whoami_show = whoami_process.communicate()[0].decode('utf-8')
     if whoami_process.returncode == 0:
@@ -179,8 +184,8 @@ def whoami(args):
         print(f"MissingLoginError: Missing login for auth.globus.org, please run \n\n \thubmap-cli login\n")
 
 
+# Forces a login to globus through the default web browser
 def login(args):
-    # Forces a login to globus through the default web browser
     print("You are running 'hubmap-clt login', which should automatically open a browser window for you to login. \n \n")
     login_process = subprocess.Popen(["globus", "login", "--force"], stdout=subprocess.PIPE)
     login_process.wait()
@@ -189,8 +194,8 @@ def login(args):
     login_process.communicate()[0].decode('utf-8')
 
 
+# Logs the user out of globus
 def logout(args):
-    # Logs the user out of globus
     logout_process = subprocess.Popen(["globus", "logout"], stdout=subprocess.PIPE)
     print("Are you sure you want to logout? [y/N]:")
     logout_process.wait()

--- a/hubmap_clt/clt-help.txt
+++ b/hubmap_clt/clt-help.txt
@@ -10,27 +10,33 @@ Commands: One of the following commands is required:
 
    transfer manifest-file   Transfer files specified in manifest-file (see
                             below for example) using Globus Transfer.
+			    The transfered files will be stored in the
+			    directory "hubmap-download" under the user's
+			    home directory.
 
    login                    Login to Globus
 
-   logout 		            Logout of Globus
+   logout 		    Logout of Globus
 
    whoami                   Displays the information of the user who is
                             currently logged in.  If no user is logged
                             a message will be displayed prompting the user
-			                to log in.
+			    to log in.
 
 -h or --help  Show this help message.
 
--d or --destionation	Manually select a download location. For example:
-                        'hubmap-clt transfer manifest-file -d Desktop' will
-                        download to the Desktop directory. 
+-d or --destionation	Manually select a download location within the user's
+                        home direcotry. For example:
+                          'hubmap-clt transfer manifest-file -d Desktop'
+			will download to the user's Desktop directory. The 
+			directory will be created under the user home directory
+			if it doesn't already exist.
 
 Manifest Files:
 Manifest files contain two columns, the first with a HuBMAP identifer the
 second with a file or directory specifier. Additional information to the
 right of the second column, separated by a tab can be included. An
-optional single header line starting with the column specifier dataset_id
+optional single header line starting with the column specifier "dataset_id"
 will be ignored.
 
 Example manifest files:

--- a/hubmap_clt/clt-help.txt
+++ b/hubmap_clt/clt-help.txt
@@ -1,4 +1,4 @@
-hubmap-clt [-h | --help] [transfer manifest-file | login | whoami]
+hubmap-clt [-h | --help] [transfer manifest-file | login | logout | whoami]
 
 HuBMAP Command Line Transfer
 

--- a/hubmap_clt/clt-help.txt
+++ b/hubmap_clt/clt-help.txt
@@ -50,5 +50,3 @@ dataset_id	file_or_dir_specifier	#header line is ignored
 HBM525.DLPN.575 /ometiffs/VAN0016-LK-202-89-IMS_PosMode_multilayer.ome.tiff #retrives image file for dataset HBM525.DLPN.575
 HBM525.DLPN.575 /ometiffs/separate/	#retrievs directory of mages files for dataset HBM525.DLPN.575
 
-
-

--- a/hubmap_clt/clt-help.txt
+++ b/hubmap_clt/clt-help.txt
@@ -50,3 +50,5 @@ dataset_id	file_or_dir_specifier	#header line is ignored
 HBM525.DLPN.575 /ometiffs/VAN0016-LK-202-89-IMS_PosMode_multilayer.ome.tiff #retrives image file for dataset HBM525.DLPN.575
 HBM525.DLPN.575 /ometiffs/separate/	#retrievs directory of mages files for dataset HBM525.DLPN.575
 
+
+

--- a/hubmap_clt/clt-help.txt
+++ b/hubmap_clt/clt-help.txt
@@ -1,0 +1,46 @@
+hubmap-clt [-h | --help] [transfer manifest-file | login | whoami]
+
+HuBMAP Command Line Transfer
+
+A utility to bulk download HuBMAP data by specifying the directories and/or
+files in a manifest file. For detailed documentation see:
+    https://software.docs.hubmapconsortium.org/using-hubmap-clt.html
+
+Commands: One of the following commands is required:
+
+   transfer manifest-file   Transfer files specified in manifest-file (see
+                            below for example) using Globus Transfer.
+
+   login                    Login to Globus
+
+   logout 		            Logout of Globus
+
+   whoami                   Displays the information of the user who is
+                            currently logged in.  If no user is logged
+                            a message will be displayed prompting the user
+			                to log in.
+
+-h or --help  Show this help message.
+
+-d or --destionation	Manually select a download location. For example:
+                        'hubmap-clt transfer manifest-file -d Desktop' will
+                        download to the Desktop directory. 
+
+Manifest Files:
+Manifest files contain two columns, the first with a HuBMAP identifer the
+second with a file or directory specifier. Additional information to the
+right of the second column, separated by a tab can be included. An
+optional single header line starting with the column specifier dataset_id
+will be ignored.
+
+Example manifest files:
+
+654418415bed5ecb9596b17a0320a2c6 /	#retrieves all files for given dataset uuid
+HBM455.XGQZ.542 /rawMicroscopy/VAN0009-LK-102-7-AF_preIMS_unregistered.czi	#retrieves czi file for dataset HBM455.XGQZ.542
+
+
+dataset_id	file_or_dir_specifier	#header line is ignored
+60ed8e03152b51d5d9c8fc04e20fa5e3 /	#retrieve all files for given dataset uuid
+HBM525.DLPN.575 /ometiffs/VAN0016-LK-202-89-IMS_PosMode_multilayer.ome.tiff #retrives image file for dataset HBM525.DLPN.575
+HBM525.DLPN.575 /ometiffs/separate/	#retrievs directory of mages files for dataset HBM525.DLPN.575
+

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     name='hubmap-clt',
     description='A command line interface to download multiple files and directories from Globus file transfer '
                 'service using a manifest file.',
-    version='1.0.0',
+    version='1.1.0',
     packages=['hubmap_clt'],
     python_requires='>=3.6',
     entry_points='''

--- a/test-manifests/manifest-bad.txt
+++ b/test-manifests/manifest-bad.txt
@@ -1,0 +1,2 @@
+adsfasdfadfadsf /
+asdfadsfadfadsf blech.txt

--- a/test-manifests/manifest-bad2.txt
+++ b/test-manifests/manifest-bad2.txt
@@ -1,0 +1,2 @@
+654418415bed5ecb9596b17a0320a2c6 / #retrieves all files for given dataset uuid
+HBM455.XGQZ.542 /rawMicroscopy/VAN0009-LK-102-7-AF_preIMS_unregistered.czi	#retrieves czi file for dataset HBM455.XGQZ.542

--- a/test-manifests/manifest-pub-and-consort.txt
+++ b/test-manifests/manifest-pub-and-consort.txt
@@ -1,0 +1,4 @@
+9eb457ab0141f7ba734e337917a9bde9 /	#public PAS
+HBM783.GDKK.879 /PAS-metadata.tsv	#public PAS file
+e6fd525b837f4cf736c8af830f4f750f /	#private/consortium CODEX
+HBM585.SPHC.855 /extras/VAN0034-RK-4-36-IMS_lipids_neg_normalizations.csv	#private/consortium file

--- a/test-manifests/manifest-space-in-filename.txt
+++ b/test-manifests/manifest-space-in-filename.txt
@@ -1,0 +1,1 @@
+e0ba24d0c4dab528e46aab3f67a1aae8 /FEB 2020 CODEX_Antibody_Panel1_UF .xlsx	#extra stuff here..

--- a/test-manifests/manifest.txt
+++ b/test-manifests/manifest.txt
@@ -1,0 +1,2 @@
+089ebad7c98cebe22f6d97b246fb45c6	/	asdfdsfadfd
+7f90e8096c701c2025c744f82f1d2600 /barcodes.txt	adfadf

--- a/test-manifests/manifest2.txt
+++ b/test-manifests/manifest2.txt
@@ -1,0 +1,2 @@
+654418415bed5ecb9596b17a0320a2c6 /	#retrieves all files for given dataset uuid
+HBM455.XGQZ.542 /rawMicroscopy/VAN0009-LK-102-7-AF_preIMS_unregistered.czi	#retrieves czi file for dataset HBM455.XGQZ.542

--- a/test-manifests/manifest3.txt
+++ b/test-manifests/manifest3.txt
@@ -1,0 +1,4 @@
+dataset_id	file_or_dir_specifier	#header line is ignored
+60ed8e03152b51d5d9c8fc04e20fa5e3 /	#retrieve all files for given dataset uuid
+HBM525.DLPN.575 /ometiffs/VAN0016-LK-202-89-IMS_PosMode_multilayer.ome.tiff	#retrives image file for dataset HBM525.DLPN.575
+HBM525.DLPN.575 /ometiffs/separate/	#retrievs directory of mages files for datase HBM525.DLPN.575


### PR DESCRIPTION
Updated help text. Originally I was manually setting "usage" in argparse.ArgumentParser(). Apparently this actually overwrote some default behavior for the help text. Removing it makes it behave predictably now. The usage is auto generated, and then if I include one of the subcommands followed by --help it will output arguments and options specific to that sub command. 

This pr also includes a change made to omit the first line of a manifest file if it starts with dataset_id. 